### PR TITLE
Fixed "requires key not supported" warning

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "mixins": [
   	"nbttooltip.client.json"
   ],
-  "requires": {
+  "depends": {
     "fabricloader": ">=0.4.0",
     "fabric": "*"
   },


### PR DESCRIPTION
Fixes "[main/WARN]: Mod `nbttooltip` (1.14-1.0.3) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends'" warning in log.